### PR TITLE
fix: fix duplicate data when pool_id is null

### DIFF
--- a/src/main/java/org/cardanofoundation/explorer/rewards/repository/jooq/JOOQRewardRepository.java
+++ b/src/main/java/org/cardanofoundation/explorer/rewards/repository/jooq/JOOQRewardRepository.java
@@ -15,6 +15,7 @@ import org.jooq.Query;
 
 import org.cardanofoundation.explorer.consumercommon.entity.Reward;
 
+import static org.jooq.impl.DSL.coalesce;
 import static org.jooq.impl.DSL.field;
 import static org.jooq.impl.DSL.table;
 
@@ -62,7 +63,7 @@ public class JOOQRewardRepository {
                   field(addressIdField),
                   field(typeField),
                   field(earnedEpochField),
-                  field(poolIdField)
+                  poolId == null ? coalesce(field(poolIdField), -1) : field(poolIdField)
               )
               .doNothing();
 

--- a/src/main/resources/db/migration/V1_2_4__add-unique-index-in-reward-table.sql
+++ b/src/main/resources/db/migration/V1_2_4__add-unique-index-in-reward-table.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX unique_reward_2 ON reward USING btree (addr_id, type, earned_epoch, coalesce(pool_id, -1));

--- a/src/test/resources/test/db/migration/V1_1_3__add-unique-index-in-reward-table.sql
+++ b/src/test/resources/test/db/migration/V1_1_3__add-unique-index-in-reward-table.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX unique_reward_2 ON reward USING btree (addr_id, type, earned_epoch, coalesce(pool_id, -1));


### PR DESCRIPTION
In this service, reward data is fetched and stored concurrently. If a reward entry has a null pool_id,  the unique constraint in reward table can be bypassed, it can lead to data duplication. Therefore, this pull request aims to address this issue by implementing a modification. It proposes adding a unique index with four values (addr_id, type, earned_epoch, coalesce(pool_id, -1)) to the reward table. This enhancement ensures that duplicate data scenarios are avoided, maintaining data consistency.

